### PR TITLE
Drop ansible.posix collection requirement

### DIFF
--- a/aee/requirements.yml
+++ b/aee/requirements.yml
@@ -1,5 +1,4 @@
 collections:
-  - name: ansible.posix
   - name: openstack.cloud
     version: 2.2.0
   - name: os_migrate.os_migrate
@@ -8,4 +7,3 @@ collections:
     version: 4.5.0
   - name: community.general
   - name: os_migrate.vmware_migration_kit
-    version: 1.3.4

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,7 +19,6 @@ dependencies:
   openstack.cloud: ">=2.0.0"
   os_migrate.os_migrate: ">=0.0.1"
   community.vmware: ">=1.0.0"
-  ansible.posix: ">=2.0.0"
 repository: "https://github.com/os-migrate/vmware-migration-kit"
 homepage: "https://github.com/os-migrate/vmware-migration-kit"
 issues: "https://github.com/os-migrate/vmware-migration-kit/issues"

--- a/playbooks/convert_metadata.yml
+++ b/playbooks/convert_metadata.yml
@@ -42,7 +42,9 @@
 
     - name: Sync to conversion host
       become: true
-      ansible.posix.synchronize:
-        src: "{{ os_migrate_vmw_data_dir }}"
+      ansible.builtin.copy:
+        remote_src: true
+        src: "{{ os_migrate_vmw_data_dir }}/"
         dest: "{{ conv_host_data_base_path }}"
+        mode: preserve
       when: copy_metadata_to_conv_host | default(false) | bool

--- a/requirements.yml
+++ b/requirements.yml
@@ -9,5 +9,3 @@ collections:
     version: ">=0.0.1"
   - name: community.vmware
     version: ">=1.0.0"
-  - name: ansible.posix
-    version: ">=2.0.0"


### PR DESCRIPTION
We're dropping the usage of the ansible posix collection, since we are using it for a single task that can be performed using a builtin module (`ansible.posix.synchronize` -> `ansible.builtin.copy`)