### PR TITLE
Rely on CentOS Stream 10 minimal as AEE base image

### DIFF
--- a/.github/workflows/ansible-test.yaml
+++ b/.github/workflows/ansible-test.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
       - name: Run ansible-test
         shell: bash
         run: make test-ansible-sanity

--- a/.github/workflows/build-aee.yml
+++ b/.github/workflows/build-aee.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup python version
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
       - name: Create and start virtual environment
         run: |
           python3 -m venv venv

--- a/aee/binddep.txt
+++ b/aee/binddep.txt
@@ -1,3 +1,4 @@
+epel-release
 openssh-clients
 sshpass
 python3

--- a/aee/build.sh
+++ b/aee/build.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-img_registry=quay.io/os-migrate/vmware-migration-kit:latest
 tag_name=vmware-migration-kit
 
 ansible-builder build --tag $tag_name
-podman push localhost/$tag_name $img_registry
+rm -fr "$(pwd)/context/"

--- a/aee/execution-environment.yml
+++ b/aee/execution-environment.yml
@@ -3,7 +3,10 @@ version: 3
 
 images:
   base_image:
-    name: quay.io/fedora/fedora:42
+    name: quay.io/centos/centos:stream10-minimal
+
+options:
+  package_manager_path: /usr/bin/microdnf
 
 dependencies:
   ansible_runner:
@@ -14,10 +17,9 @@ dependencies:
   system: binddep.txt
   galaxy: requirements.yml
   python_interpreter:
-    package_system: "python3.13"
-    python_path: "/usr/bin/python3.13"
+    package_system: "python3"
+    python_path: "/usr/bin/python3"
 additional_build_steps:
   prepend_base:
-    - "RUN  echo 'cloud-user ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/cloud-user"
-  append_final:
-    - "RUN  pip install openstacksdk"
+    - "RUN mkdir -p /etc/sudoers.d"
+    - "RUN echo 'cloud-user ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/cloud-user"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -28,3 +28,4 @@ build_ignore:
   - .pytest_cache
   - tests/output
   - tests/__pycache__
+  - aee/context


### PR DESCRIPTION
Since the release cycle of Fedora is too short (6 months, with 2 releases officially supported), we're switching our container image to CentOS Stream 10 which guarantee the right balance between stability and right features.

To ease this transition, we switch the python version used for tests to 3.12 which is available on both Fedora (41/42) and CentOS Stream 10