### PR TITLE
new: Add support for booting instances from existing Cinder volumes

### DIFF
--- a/plugins/modules/create_server/create_server.go
+++ b/plugins/modules/create_server/create_server.go
@@ -23,6 +23,10 @@ import (
 	"vmware-migration-kit/plugins/module_utils/ansible"
 	"vmware-migration-kit/plugins/module_utils/logger"
 	osm_os "vmware-migration-kit/plugins/module_utils/openstack"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
 )
 
 /* Argument file example:
@@ -64,6 +68,7 @@ type ModuleArgs struct {
 	SecurityGroups []string        `json:"security_groups"`
 	Flavor         string          `json:"flavor"`
 	KeyName        string          `json:"key_name"`
+	BootFromCinder bool            `json:"boot_from_cinder"`
 }
 
 type ModuleResponse struct {
@@ -106,6 +111,7 @@ func main() {
 		response.Msg = "Configuration file not valid JSON: " + string(text)
 		ansible.FailJson(response)
 	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	provider, err := osm_os.OpenstackAuth(ctx, moduleArgs.Cloud)
@@ -113,6 +119,46 @@ func main() {
 		logger.Log.Infof("Failed to authenticate Openstack client: %v", err)
 		response.Msg = "Failed to authenticate Openstack client: " + err.Error()
 		ansible.FailJson(response)
+	}
+
+	if moduleArgs.BootFromCinder {
+		blockStorageClient, err := openstack.NewBlockStorageV3(provider, gophercloud.EndpointOpts{
+			Region: os.Getenv("OS_REGION_NAME"),
+		})
+		if err != nil {
+			logger.Log.Infof("Failed to create block storage client: %v", err)
+			response.Msg = "Failed to create block storage client: " + err.Error()
+			ansible.FailJson(response)
+		}
+
+		volume, err := volumes.Get(ctx, blockStorageClient, moduleArgs.BootVolume).Extract()
+		if err != nil {
+			logger.Log.Infof("Failed to get volume: %v", err)
+			response.Msg = "Failed to get volume: " + err.Error()
+			ansible.FailJson(response)
+		}
+
+		if volume.Bootable != "true" {
+			logger.Log.Infof("Volume is not bootable")
+			response.Msg = "Volume is not bootable"
+			ansible.FailJson(response)
+		}
+
+		ServerAgrs := osm_os.ServerArgs{
+			Name:           moduleArgs.Name,
+			Flavor:         moduleArgs.Flavor,
+			BootVolume:     moduleArgs.BootVolume,
+			SecurityGroups: moduleArgs.SecurityGroups,
+			Nics:           moduleArgs.Nics,
+			Volumes:        moduleArgs.Volumes,
+		}
+		server, err := osm_os.CreateServer(provider, ServerAgrs)
+		if err != nil {
+			response.Msg = "Failed create instance: " + err.Error()
+			ansible.FailJson(response)
+		}
+		success(true, server)
+		return
 	}
 
 	ServerAgrs := osm_os.ServerArgs{

--- a/plugins/modules/create_server/create_server.go
+++ b/plugins/modules/create_server/create_server.go
@@ -144,6 +144,12 @@ func main() {
 			ansible.FailJson(response)
 		}
 
+		if volume.Status != "available" {
+			logger.Log.Infof("Volume is not available, current status: %s", volume.Status)
+			response.Msg = "Volume is not available"
+			ansible.FailJson(response)
+		}
+
 		ServerAgrs := osm_os.ServerArgs{
 			Name:           moduleArgs.Name,
 			Flavor:         moduleArgs.Flavor,

--- a/plugins/modules/create_server/create_server.go
+++ b/plugins/modules/create_server/create_server.go
@@ -123,7 +123,7 @@ func main() {
 
 	if moduleArgs.BootFromCinder {
 		blockStorageClient, err := openstack.NewBlockStorageV3(provider, gophercloud.EndpointOpts{
-			Region: os.Getenv("OS_REGION_NAME"),
+			Region: moduleArgs.Cloud.RegionName,
 		})
 		if err != nil {
 			logger.Log.Infof("Failed to create block storage client: %v", err)

--- a/roles/import_workloads/defaults/main.yml
+++ b/roles/import_workloads/defaults/main.yml
@@ -21,3 +21,5 @@ import_workloads_image_metadata:
   - hw_firmware_type='uefi'
   - hw_boot_mode='uefi'
   - cinder_img_volume_type='rhcs6-gp3'
+
+import_workloads_boot_from_cinder: "{{ boot_from_cinder | default(false) | bool }}"

--- a/roles/import_workloads/tasks/create_os_instance.yml
+++ b/roles/import_workloads/tasks/create_os_instance.yml
@@ -12,24 +12,36 @@
   environment:
     OS_CLOUD: "{{ openstack_cloud }}"
 
-- name: Get volume information
+- name: Get volume information for virt-v2v
   openstack.cloud.volume_info:
     cloud: "{{ dst_cloud }}"
     name: "{{ vm_name }}-sda"
   register: volume_result
   when: import_workloads_os_migrate_virt_v2v
 
-- name: Set boot volume UUID as a fact
+- name: Get volume information for Cinder boot
+  openstack.cloud.volume_info:
+    cloud: "{{ dst_cloud }}"
+    name: "{{ vm_name }}"
+  register: cinder_volume_result
+  when: import_workloads_boot_from_cinder
+
+- name: Set boot volume UUID as a fact for virt-v2v
   ansible.builtin.set_fact:
     boot_volume_uuid: "{{ volume_result.volumes[0].id }}"
   when: import_workloads_os_migrate_virt_v2v
 
-- name: Set boot volume UUID as a fact
+- name: Set boot volume UUID as a fact for nbdkit
   ansible.builtin.set_fact:
     boot_volume_uuid: "{{ volume_uuid[0] }}"
   when: import_workloads_os_migrate_nbdkit
 
-- name: Set boot volume UUID as a fact
+- name: Set boot volume UUID as a fact for Cinder boot
+  ansible.builtin.set_fact:
+    boot_volume_uuid: "{{ cinder_volume_result.volumes[0].id }}"
+  when: import_workloads_boot_from_cinder
+
+- name: Set additional volumes list for nbdkit
   ansible.builtin.set_fact:
     volumes_list: "{{ volume_uuid[1:] | default([]) }}"
   when: import_workloads_os_migrate_nbdkit
@@ -59,6 +71,7 @@
         security_groups: ["{{ security_groups }}"]
         flavor: "{{ flavor_name_or_uuid }}"
         key_name: "{{ ssh_key_name | default('') }}"
+        boot_from_cinder: "{{ import_workloads_boot_from_cinder }}"
       delegate_to: localhost
 
     - name: Set fact for instance_uuid


### PR DESCRIPTION
This PR covers https://issues.redhat.com/browse/OSPRH-9720

## New Variables
The following variables have been added to the role:

```yaml
# roles/import_workloads/defaults/main.yml
import_workloads_boot_from_cinder: "{{ boot_from_cinder | default(false) | bool }}"
```

To create an instance from an existing Cinder volume, set the following variables in your playbook:

```yaml
- name: Create instance from existing volume
  hosts: localhost
  tasks:
    - name: Create instance
      include_role:
        name: import_workloads
        tasks_from: create_os_instance
      vars:
        boot_from_cinder: true
        boot_volume: "your-volume-id-or-name"
        name: "your-instance-name"
        flavor: "your-flavor"
        nics: 
          - port-id: "your-port-id"
        security_groups: ["your-security-group"]
```

The existing volume must meet the following criteria:
- Must be a valid Cinder volume
- Must be marked as bootable
- Must be in an available state

The existing NBD import workflow remains unchanged and is still the default behavior. The new Cinder boot functionality is only enabled when `boot_from_cinder` is set to `true`.
