### PR TITLE
Removed `pyupgrade` pre-commit hook and restored python2 compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,6 @@ repos:
       - id: check-json
       - id: check-merge-conflict
       - id: fix-byte-order-marker
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
-    hooks:
-      - id: pyupgrade
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 25.1.0
     hooks:

--- a/plugins/module_utils/v2v_wrapper.py
+++ b/plugins/module_utils/v2v_wrapper.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
 import subprocess
 
 

--- a/plugins/modules/best_match_flavor.py
+++ b/plugins/modules/best_match_flavor.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
 
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",

--- a/plugins/modules/create_network_port.py
+++ b/plugins/modules/create_network_port.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
 
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",

--- a/plugins/modules/export_flavor.py
+++ b/plugins/modules/export_flavor.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
 
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",

--- a/plugins/modules/import_vmware_volume.py
+++ b/plugins/modules/import_vmware_volume.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
 
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",


### PR DESCRIPTION
Python2 compatibility is still a requirement for the Ansible Automation Hub so we're going to restore it.

pypugrade hook isn't very customizable so we can't adopt it.