### PR TITLE
Fix packages installation

### DIFF
--- a/roles/conversion_host/tasks/main.yml
+++ b/roles/conversion_host/tasks/main.yml
@@ -7,16 +7,15 @@
 
 - name: Make sure required package are installed
   ansible.builtin.dnf:
-    name: "{{ item }}"
+    name:
+      - libvirt
+      - virt-v2v
+      - qemu-kvm
+      - python3
+      - python3-pip
+      - wget
     state: present
     use_backend: dnf4
-  with_items:
-    - libvirt
-    - virt-v2v
-    - qemu-kvm
-    - python3
-    - python3-pip
-    - wget
 
 - name: Gather installed package facts
   ansible.builtin.package_facts:


### PR DESCRIPTION
`ansible.builtin.dnf` accepts a list as its argument for `name` parameter. Using a loop slowed down the installation of the packages because dnf is executed $n times (where n = len(list))