### PR TITLE
Added funtion to replace dangerous characters in VM name

### DIFF
--- a/plugins/module_utils/nbdkit/nbdkit.go
+++ b/plugins/module_utils/nbdkit/nbdkit.go
@@ -30,6 +30,7 @@ import (
 	"time"
 	"vmware-migration-kit/plugins/module_utils/logger"
 	"vmware-migration-kit/plugins/module_utils/vmware"
+	moduleutils "vmware-migration-kit/plugins/module_utils"
 )
 
 type NbdkitConfig struct {
@@ -51,7 +52,8 @@ type NbdkitServer struct {
 
 func (c *NbdkitConfig) RunNbdKitFromLocal(diskName, diskPath string) (*NbdkitServer, error) {
 	path := path.Join(diskPath, diskName)
-	socket := fmt.Sprintf("/tmp/nbdkit-%s-%s.sock", c.VmName, c.UUID)
+	safeVmName := moduleutils.SafeVmName(c.VmName)
+	socket := fmt.Sprintf("/tmp/nbdkit-%s-%s.sock", safeVmName, c.UUID)
 	cmd := exec.Command(
 		"nbdkit",
 		"--readonly",
@@ -154,7 +156,8 @@ func (c *NbdkitConfig) RunNbdKitSocks(diskName string) (*NbdkitServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	socket := fmt.Sprintf("/tmp/nbdkit-%s-%s.sock", c.VmName, c.UUID)
+	safeVmName := moduleutils.SafeVmName(c.VmName)
+	socket := fmt.Sprintf("/tmp/nbdkit-%s-%s.sock", safeVmName, c.UUID)
 	cmd := exec.Command(
 		"nbdkit",
 		"--readonly",

--- a/plugins/module_utils/utils.go
+++ b/plugins/module_utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"regexp"
 )
 
 func FindDevName(volumeID string) (string, error) {
@@ -54,4 +55,9 @@ func GenRandom(length int) (string, error) {
 		result[i] = charset[num.Int64()]
 	}
 	return string(result), nil
+}
+
+func SafeVmName(vmName string) string {
+    re := regexp.MustCompile(`[^a-zA-Z0-9_]`)
+    return re.ReplaceAllString(vmName, "_")
 }

--- a/plugins/modules/src/migrate/migrate.go
+++ b/plugins/modules/src/migrate/migrate.go
@@ -424,7 +424,8 @@ func main() {
 		response.Msg = "Failed to generate random string"
 		ansible.FailJson(response)
 	}
-	LogFile := "/tmp/osm-nbdkit-" + vmname + "-" + r + ".log"
+	safeVmName := moduleutils.SafeVmName(vmname)
+	LogFile := "/tmp/osm-nbdkit-" + safeVmName + "-" + r + ".log"
 	logger.InitLogger(LogFile)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
VMware allows creating workloads with special characters (such as spaces) in their names. When these names are appended to the nbd socket or log filenames, they can introduce conflicts when handling these files.

This PR replaces special characters with underscores (_), ensuring that socket and log names are safe and free of conflicts.