### PR TITLE
add future import and metaclass boilerplate

### DIFF
--- a/plugins/modules/warn.py
+++ b/plugins/modules/warn.py
@@ -18,6 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 DOCUMENTATION = r'''
 ---
 module: warn


### PR DESCRIPTION
Noticed future import and metaclass boilerplate is missing during ansible-test sanity. See the import logs for v2.1.4: https://console.redhat.com/ansible/automation-hub/my-imports/?namespace=os_migrate

