### PR TITLE
map clear errors for mapped network errors

### DIFF
--- a/roles/export_metadata/tasks/network.yml
+++ b/roles/export_metadata/tasks/network.yml
@@ -51,6 +51,24 @@
       run_once: true
       when: used_mapped_networks|default(true)|bool
 
+    - name: Validate that at least one network was mapped
+      ansible.builtin.fail:
+        msg: |
+          ERROR: No networks were mapped for VM '{{ vm_name }}'.
+
+          VMware networks found on this VM:
+          {% for eth in vm_info_file.keys() | select('match', '^hw_eth[0-9]+$') | list %}
+          - {{ vm_info_file[eth].summary }}
+          {% endfor %}
+
+          Your current network_map:
+          {{ network_map | to_nice_json }}
+
+          None of the VM's networks match your network_map configuration.
+          Please update 'network_map' in vars.yaml to include mappings for the networks above.
+      when:
+        - guest_nic is not defined or guest_nic | length == 0
+
 - name: Extract macs addresses for non mapped networks
   when: not used_mapped_networks
   block:

--- a/roles/export_metadata/tasks/vm_info.yml
+++ b/roles/export_metadata/tasks/vm_info.yml
@@ -8,6 +8,19 @@
     name: "{{ vm_name }}"
   register: guest_info
 
+- name: Validate VM was found
+  ansible.builtin.fail:
+    msg: |
+      ERROR: VM '{{ vm_name }}' was not found in vCenter.
+
+      Please verify:
+      - The VM name is correct (case sensitive)
+      - The VM exists in vCenter: {{ vcenter_hostname }}
+      - The VM is in datacenter: {{ vcenter_datacenter }}
+
+      Check your 'vms_list' parameter in vars.yaml
+  when: guest_info.guests | length == 0
+
 - name: Dump guest_info file
   ansible.builtin.copy:
     content: "{{ guest_info.guests[0] | to_nice_json }}"


### PR DESCRIPTION
When the mapped network is not found in export metadata tasks. Ansible returns syntax error with guest_nic variable.

We need to specify that the network name is not found and even print the one present in the json file in order to help user to understand which param is wrong.