### PR TITLE
feat: sanitize VM names for OpenStack resource naming

### DIFF
--- a/plugins/modules/src/create_network_port/create_network_port.go
+++ b/plugins/modules/src/create_network_port/create_network_port.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	moduleutils "vmware-migration-kit/plugins/module_utils"
 	"vmware-migration-kit/plugins/module_utils/logger"
 	osm_os "vmware-migration-kit/plugins/module_utils/openstack"
 )
@@ -181,7 +182,7 @@ func main() {
 				}
 			}
 		}
-		portName := fmt.Sprintf("%s-NIC-%d-VLAN-%s", moduleArgs.VmName, nicIndex, nic.Vlan)
+		portName := fmt.Sprintf("%s-NIC-%d-VLAN-%s", moduleutils.SafeVmName(moduleArgs.VmName), nicIndex, nic.Vlan)
 		port, err := osm_os.CreatePort(provider, portName, network.ID, nic.Mac, nic.Subnet,
 			moduleArgs.SecurityGroups, nic.FixedIPs)
 		if err != nil {

--- a/plugins/modules/src/create_server/create_server.go
+++ b/plugins/modules/src/create_server/create_server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	moduleutils "vmware-migration-kit/plugins/module_utils"
 	"vmware-migration-kit/plugins/module_utils/ansible"
 	"vmware-migration-kit/plugins/module_utils/logger"
 	osm_os "vmware-migration-kit/plugins/module_utils/openstack"
@@ -153,7 +154,7 @@ func main() {
 		}
 
 		ServerAgrs := osm_os.ServerArgs{
-			Name:             moduleArgs.Name,
+			Name:             moduleutils.SafeVmName(moduleArgs.Name),
 			Flavor:           moduleArgs.Flavor,
 			BootVolume:       moduleArgs.BootVolume,
 			SecurityGroups:   moduleArgs.SecurityGroups,
@@ -172,7 +173,7 @@ func main() {
 	}
 
 	ServerAgrs := osm_os.ServerArgs{
-		Name:             moduleArgs.Name,
+		Name:             moduleutils.SafeVmName(moduleArgs.Name),
 		Flavor:           moduleArgs.Flavor,
 		BootVolume:       moduleArgs.BootVolume,
 		SecurityGroups:   moduleArgs.SecurityGroups,

--- a/plugins/modules/src/migrate/migrate.go
+++ b/plugins/modules/src/migrate/migrate.go
@@ -144,7 +144,7 @@ func (c *MigrationConfig) VMMigration(parentCtx context.Context, runV2V bool) (s
 		return "", err
 	}
 	diskNameStr := strconv.Itoa(int(c.NbdkitConfig.VddkConfig.DiskKey))
-	volume, err := osm_os.GetVolumeID(c.OSClient, vmName, diskNameStr)
+	volume, err := osm_os.GetVolumeID(c.OSClient, moduleutils.SafeVmName(vmName), diskNameStr)
 	if err != nil {
 		logger.Log.Infof("Failed to get volume: %v", err)
 		return "", err
@@ -223,7 +223,7 @@ func (c *MigrationConfig) VMMigration(parentCtx context.Context, runV2V bool) (s
 		// 	volumeMetadata["hw_scsi_model"] = "virtio-scsi"
 		// }
 		volOpts := osm_os.VolOpts{
-			Name:             vmName + "-" + diskNameStr,
+			Name:             moduleutils.SafeVmName(vmName) + "-" + diskNameStr,
 			Size:             int(diskSize[diskNameStr] / 1024 / 1024),
 			VolumeType:       c.VolumeType,
 			AvailabilityZone: c.VolumeAz,


### PR DESCRIPTION
## Summary

VM names in VMware environments often contain accented characters,
special symbols or other characters that are not valid in OpenStack
resource names. This was causing failures or unexpected names in
Cinder volumes, Nova instances and Neutron ports.

## Changes

### `plugins/module_utils/utils.go`

Extended `SafeVmName` with three additional sanitization steps:

- **Transliteration**: common non-ASCII characters are mapped to their
  ASCII equivalent before the regex runs (e.g. `ñ→n`, `ß→ss`, `ç→c`,
  `á→a`). Covers Spanish, Portuguese, French, German and extended Latin.
- **Underscore collapsing**: consecutive underscores produced by the
  replacement step are collapsed into one (e.g. `vm--01 → vm_01`).
- **Length limit**: result is truncated to 64 characters and any
  trailing underscore left after truncation is stripped.

### `plugins/modules/src/migrate/migrate.go`

`SafeVmName` is now applied to `vmName` when looking up an existing
volume and when setting the name of a newly created volume.

### `plugins/modules/src/create_server/create_server.go`

`SafeVmName` is now applied to `moduleArgs.Name` in both code paths
that create a Nova instance.

### `plugins/modules/src/create_network_port/create_network_port.go`

`SafeVmName` is now applied to `moduleArgs.VmName` when constructing
the Neutron port name.

### `tests/unit/utils_test.go`

Updated existing test expectations to match the new behaviour and added
test cases covering underscore collapsing, transliteration (accented
vowels, ñ, ß, ç), truncation to 64 characters and trailing-underscore
stripping after truncation.

## Testing

```
go test -v ./tests/unit/...
```