### PR TITLE
round up insteading of rounding down volume size

### DIFF
--- a/plugins/modules/src/migrate/migrate.go
+++ b/plugins/modules/src/migrate/migrate.go
@@ -224,7 +224,7 @@ func (c *MigrationConfig) VMMigration(parentCtx context.Context, runV2V bool) (s
 		// }
 		volOpts := osm_os.VolOpts{
 			Name:             vmName + "-" + diskNameStr,
-			Size:             int(diskSize[diskNameStr] / 1024 / 1024),
+			Size:             int((diskSize[diskNameStr] + 1024*1024 - 1) / (1024 * 1024),
 			VolumeType:       c.VolumeType,
 			AvailabilityZone: c.VolumeAz,
 			BusType:          "virtio",

--- a/plugins/modules/src/migrate/migrate.go
+++ b/plugins/modules/src/migrate/migrate.go
@@ -224,7 +224,7 @@ func (c *MigrationConfig) VMMigration(parentCtx context.Context, runV2V bool) (s
 		// }
 		volOpts := osm_os.VolOpts{
 			Name:             vmName + "-" + diskNameStr,
-			Size:             int((diskSize[diskNameStr] + 1024*1024 - 1) / (1024 * 1024),
+			Size:             int((diskSize[diskNameStr] + 1024*1024 - 1) / (1024 * 1024)),
 			VolumeType:       c.VolumeType,
 			AvailabilityZone: c.VolumeAz,
 			BusType:          "virtio",


### PR DESCRIPTION
During the migration, I encountered the following error:

7Z" level=info msg="[nbdcopy stderr] nbdcopy: error: destination size (20401094656) is smaller than source size (20971520000)\n"

The VM to be migrated on the vSphere side had a size of 19.53125 GB (corresponding to 20,971,520,000 bytes).

`	Size:             int(diskSize[diskNameStr] / 1024 / 1024),`

This converts the size to 19 GB, which is too small.

`	Size:             int((diskSize[diskNameStr] + 1024*1024 - 1) / (1024 * 1024),`

would convert is to 20GB