### PR TITLE
v2.2.2 release for vmware-kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,16 +201,16 @@ Minor release which removes unused import_image module and fix AEE push
 
 ## v2.2.2
 
-- Add unit tests for openstack and vmware modules by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/200
-- Remove useless dep in bindep files by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/207
-- test: add unit tests for nbdkit module by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/205
-- test: add unit tests for utils.go by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/209
-- Extend fake openstack server to support more services by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/210
-- Update port device and status metadata when needed by @fdiazbra in https://github.com/os-migrate/vmware-migration-kit/pull/212
-- Normalize v2/ path when gophercloud send weird uri by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/211
-- Move AEE base image to ubi 9.7 by @fdiazbra in https://github.com/os-migrate/vmware-migration-kit/pull/208
-- Upgrade go version and golintci job by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/216
-- test: integration tests for new srv.go capabilites by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/214
-- Update check jobs with new go version by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/217
-- Enhance mock server and integration tests coverage by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/221
-- Mock updates by @fdiazbra in https://github.com/os-migrate/vmware-migration-kit/pull/220
+- Add unit tests for openstack and vmware modules
+- Remove useless dep in bindep files
+- test: add unit tests for nbdkit module
+- test: add unit tests for utils.go
+- Extend fake openstack server to support more services
+- Update port device and status metadata when needed
+- Normalize v2/ path when gophercloud send weird uri
+- Move AEE base image to ubi 9.7
+- Upgrade go version and golintci job
+- test: integration tests for new srv.go capabilites
+- Update check jobs with new go version
+- Enhance mock server and integration tests coverage
+- Mock updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,9 +158,9 @@ Minor release which removes unused import_image module and fix AEE push
 
 ## v2.1.5
 
-- Run sanity test on each required versions of python 
+- Run sanity test on each required versions of python
 - Remove f-strings for python retrocompatibility
-- Add future import and metaclass boilerplate 
+- Add future import and metaclass boilerplate
 - Update readme links
 
 ## v2.1.6
@@ -198,3 +198,19 @@ Minor release which removes unused import_image module and fix AEE push
 
 - Add AGENTS.md file for AI agent guidelines
 - remove parseable which is now not allowed
+
+## v2.2.2
+
+- Add unit tests for openstack and vmware modules by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/200
+- Remove useless dep in bindep files by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/207
+- test: add unit tests for nbdkit module by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/205
+- test: add unit tests for utils.go by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/209
+- Extend fake openstack server to support more services by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/210
+- Update port device and status metadata when needed by @fdiazbra in https://github.com/os-migrate/vmware-migration-kit/pull/212
+- Normalize v2/ path when gophercloud send weird uri by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/211
+- Move AEE base image to ubi 9.7 by @fdiazbra in https://github.com/os-migrate/vmware-migration-kit/pull/208
+- Upgrade go version and golintci job by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/216
+- test: integration tests for new srv.go capabilites by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/214
+- Update check jobs with new go version by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/217
+- Enhance mock server and integration tests coverage by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/221
+- Mock updates by @fdiazbra in https://github.com/os-migrate/vmware-migration-kit/pull/220

--- a/aee/execution-environment.yml
+++ b/aee/execution-environment.yml
@@ -20,7 +20,7 @@ dependencies:
     package_system: "python3"
     python_path: "/usr/bin/python3"
 additional_build_files:
-  - src: ../os_migrate-vmware_migration_kit-2.2.1.tar.gz
+  - src: ../os_migrate-vmware_migration_kit-2.2.2.tar.gz
     dest: tmp/
 additional_build_steps:
   prepend_base:

--- a/aee/requirements.yml
+++ b/aee/requirements.yml
@@ -5,4 +5,4 @@ collections:
     version: 4.9.0
   - name: os_migrate.vmware_migration_kit
     type: file
-    source: tmp/os_migrate-vmware_migration_kit-2.2.1.tar.gz
+    source: tmp/os_migrate-vmware_migration_kit-2.2.2.tar.gz

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: os_migrate
 name: vmware_migration_kit
-version: 2.2.1
+version: 2.2.2
 readme: README.md
 authors:
   - Mathieu Bultel <mat.bultel@gmail.com>


### PR DESCRIPTION
- Add unit tests for openstack and vmware modules by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/200
- Remove useless dep in bindep files by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/207
- test: add unit tests for nbdkit module by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/205
- test: add unit tests for utils.go by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/209
- Extend fake openstack server to support more services by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/210
- Update port device and status metadata when needed by @fdiazbra in https://github.com/os-migrate/vmware-migration-kit/pull/212
- Normalize v2/ path when gophercloud send weird uri by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/211
- Move AEE base image to ubi 9.7 by @fdiazbra in https://github.com/os-migrate/vmware-migration-kit/pull/208
- Upgrade go version and golintci job by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/216
- test: integration tests for new srv.go capabilites by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/214
- Update check jobs with new go version by @matbu in https://github.com/os-migrate/vmware-migration-kit/pull/217
- Enhance mock server and integration tests coverage by @vyvle in https://github.com/os-migrate/vmware-migration-kit/pull/221
- Mock updates by @fdiazbra in https://github.com/os-migrate/vmware-migration-kit/pull/220