### PR TITLE
fix: cinder vol mismatch over SafeVmName logic

### DIFF
--- a/plugins/module_utils/utils.go
+++ b/plugins/module_utils/utils.go
@@ -119,18 +119,20 @@ func transliterate(vmName string) string {
 
 // SafeVmName sanitizes a VMware VM name for use as an OpenStack resource name.
 // It transliterates common non-ASCII characters, replaces any remaining
-// non-alphanumeric characters (except underscore) with underscores, collapses
-// consecutive underscores into one, truncates to 64 characters, and strips
-// any trailing underscores left after truncation.
+// non-alphanumeric characters (except underscore and ASCII hyphen) with underscores,
+// collapses consecutive underscores and consecutive hyphens, truncates to 64 characters,
+// and strips trailing underscores and hyphens left after truncation.
 func SafeVmName(vmName string) string {
 	safe := transliterate(vmName)
-	re := regexp.MustCompile(`[^a-zA-Z0-9_]`)
+	re := regexp.MustCompile(`[^a-zA-Z0-9_-]`)
 	safe = re.ReplaceAllString(safe, "_")
 	multi := regexp.MustCompile(`_+`)
 	safe = multi.ReplaceAllString(safe, "_")
+	hyphenMulti := regexp.MustCompile(`-+`)
+	safe = hyphenMulti.ReplaceAllString(safe, "-")
 	if len(safe) > 64 {
 		safe = safe[:64]
 	}
-	safe = strings.TrimRight(safe, "_")
+	safe = strings.TrimRight(safe, "_-")
 	return safe
 }

--- a/tests/unit/utils_test.go
+++ b/tests/unit/utils_test.go
@@ -222,14 +222,14 @@ func TestSafeVmName(t *testing.T) {
 	}{
 		// Basic cases (existing)
 		{"vm1", "vm1"},
-		{"vm-01", "vm_01"},
+		{"vm-01", "vm-01"},
 		{"My VM", "My_VM"},
 		{"vm@#$%", "vm"},
 		{"_already_ok_", "_already_ok"},
 		{" ", ""},
-		{"Mi-VM.2025", "Mi_VM_2025"},
-		// Underscore collapsing
-		{"vm--01", "vm_01"},
+		{"Mi-VM.2025", "Mi-VM_2025"},
+		// Underscore / hyphen collapsing
+		{"vm--01", "vm-01"},
 		{"vm...test", "vm_test"},
 		{"VM  prod", "VM_prod"},
 		{"vm___server", "vm_server"},
@@ -237,7 +237,7 @@ func TestSafeVmName(t *testing.T) {
 		{"ñoño", "nono"},
 		{"Ángel_García", "Angel_Garcia"},
 		{"Açaí_VM", "Acai_VM"},
-		{"Muñoz-Server", "Munoz_Server"},
+		{"Muñoz-Server", "Munoz-Server"},
 		{"Ñoño_Server", "Nono_Server"},
 		// Transliteration - accented vowels
 		{"áéíóú", "aeiou"},


### PR DESCRIPTION
Ensure vm names e.g. `haproxy-qmrkc` stays `haproxy-qmrkc`, so Cinder gets `haproxy-qmrkc-2000`, which matches name: `"{{ item }}-{{ vm_boot_disk_keys[item] }}"`. The mismatch came from `SafeVmName` treating like other “unsafe” characters and turning it into `_`, while Ansible still builds `{{ vm_name }}-{{ disk_key }}` with the original VM name (hyphens kept). This treats ASCII as allowed, collapse runs of hyphens to a single `-`, and trim trailing `-` and `_` after truncation (same idea as before for `_`).