### PR TITLE
Multicall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,14 +112,14 @@ clean-binaries: check-root
 		echo "*** Error: $(MODULES_DIR) directory not found. ***"; \
 		exit 1; \
 	fi
-	@# Count files that would be deleted
-	@files_to_delete=$$(find $(MODULES_DIR) -type f ! -name "*.py" -a ! -name "*.go" | wc -l); \
+	@# Count files and symlinks that would be deleted
+	@files_to_delete=$$(find $(MODULES_DIR) \( -type f ! -name "*.py" ! -name "*.go" -o -type l \) | wc -l); \
 	if [ $$files_to_delete -eq 0 ]; then \
 		echo "*** No binary files found to delete in $(MODULES_DIR) ***"; \
 	else \
 		echo "*** Found $$files_to_delete files to delete ***"; \
 		echo "*** Removing binary files from $(MODULES_DIR) ... ***"; \
-		find $(MODULES_DIR) -type f ! -name "*.go" -a ! -name "*.py" -delete; \
+		find $(MODULES_DIR) \( -type f ! -name "*.go" ! -name "*.py" -o -type l \) -delete; \
 		echo "*** Cleanup complete. ***"; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,7 @@ test-ansible-sanity:
 	  --exclude plugins/modules/delete_server \
 	  --exclude plugins/modules/delete_volume \
 	  --exclude plugins/modules/flavor_info \
+	  --exclude plugins/modules/module_dispatcher \
 	  --exclude plugins/modules/migrate \
 	  --exclude plugins/modules/volume_info \
 	  --exclude plugins/modules/volume_metadata_info && \

--- a/plugins/modules/src/best_match_flavor/best_match_flavor.go
+++ b/plugins/modules/src/best_match_flavor/best_match_flavor.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package main
+package best_match_flavor
 
 import (
 	"context"
@@ -168,7 +168,7 @@ func findBestMatchingFlavor(provider *gophercloud.ProviderClient, guestInfo *Gue
 	return bestFlavor, nil
 }
 
-func main() {
+func Run() {
 	var response Response
 	if len(os.Args) != 2 {
 		response.Msg = "No argument file provided"

--- a/plugins/modules/src/create_heat_stack/create_heat_stack.go
+++ b/plugins/modules/src/create_heat_stack/create_heat_stack.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package main
+package create_heat_stack
 
 import (
 	"context"
@@ -98,7 +98,7 @@ func waitForStackStatus(ctx context.Context, client *gophercloud.ServiceClient, 
 	}
 }
 
-func main() {
+func Run() {
 	if len(os.Args) != 2 {
 		ansible.FailJson(ansible.Response{Msg: "No argument file provided"})
 	}

--- a/plugins/modules/src/create_network_port/create_network_port.go
+++ b/plugins/modules/src/create_network_port/create_network_port.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package main
+package create_network_port
 
 import (
 	"context"
@@ -110,7 +110,7 @@ func loadJSONFile(filePath string, target interface{}) error {
 	return nil
 }
 
-func main() {
+func Run() {
 	var response Response
 	if len(os.Args) != 2 {
 		response.Msg = "No argument file provided"

--- a/plugins/modules/src/create_server/create_server.go
+++ b/plugins/modules/src/create_server/create_server.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package main
+package create_server
 
 import (
 	"context"
@@ -94,7 +94,7 @@ func success(changed bool, id string) {
 	os.Exit(0)
 }
 
-func main() {
+func Run() {
 	var response ansible.Response
 	if len(os.Args) != 2 {
 		response.Msg = "No argument file provided"

--- a/plugins/modules/src/delete_flavor/delete_flavor.go
+++ b/plugins/modules/src/delete_flavor/delete_flavor.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package main
+package delete_flavor
 
 import (
 	"context"
@@ -65,7 +65,7 @@ func returnResponse(responseBody Response) {
 	}
 }
 
-func main() {
+func Run() {
 	var response Response
 	if len(os.Args) != 2 {
 		response.Msg = "No argument file provided"

--- a/plugins/modules/src/delete_port/delete_port.go
+++ b/plugins/modules/src/delete_port/delete_port.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package main
+package delete_port
 
 import (
 	"context"
@@ -65,7 +65,7 @@ func returnResponse(responseBody Response) {
 	}
 }
 
-func main() {
+func Run() {
 	var response Response
 	if len(os.Args) != 2 {
 		response.Msg = "No argument file provided"

--- a/plugins/modules/src/delete_server/delete_server.go
+++ b/plugins/modules/src/delete_server/delete_server.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package main
+package delete_server
 
 import (
 	"context"
@@ -65,7 +65,7 @@ func returnResponse(responseBody Response) {
 	}
 }
 
-func main() {
+func Run() {
 	var response Response
 	if len(os.Args) != 2 {
 		response.Msg = "No argument file provided"

--- a/plugins/modules/src/delete_volume/delete_volume.go
+++ b/plugins/modules/src/delete_volume/delete_volume.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package main
+package delete_volume
 
 import (
 	"context"
@@ -65,7 +65,7 @@ func returnResponse(responseBody Response) {
 	}
 }
 
-func main() {
+func Run() {
 	var response Response
 	if len(os.Args) != 2 {
 		response.Msg = "No argument file provided"

--- a/plugins/modules/src/flavor_info/flavor_info.go
+++ b/plugins/modules/src/flavor_info/flavor_info.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package main
+package flavor_info
 
 import (
 	"context"
@@ -66,7 +66,7 @@ func returnResponse(responseBody Response) {
 	}
 }
 
-func main() {
+func Run() {
 	var response Response
 	if len(os.Args) != 2 {
 		response.Msg = "No argument file provided"

--- a/plugins/modules/src/generate_heat_template/generate_heat_template.go
+++ b/plugins/modules/src/generate_heat_template/generate_heat_template.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package main
+package generate_heat_template
 
 import (
 	"encoding/json"
@@ -173,7 +173,7 @@ func generateHeatTemplate(vmsData []VMData, stackName string) (string, map[strin
 	return template.String(), parameters
 }
 
-func main() {
+func Run() {
 	if len(os.Args) != 2 {
 		ansible.FailJson(ansible.Response{Msg: "No argument file provided"})
 	}

--- a/plugins/modules/src/import_flavor/import_flavor.go
+++ b/plugins/modules/src/import_flavor/import_flavor.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  */
 
-package main
+package import_flavor
 
 import (
 	"context"
@@ -110,7 +110,7 @@ func fail(msg string) {
 	os.Exit(1)
 }
 
-func main() {
+func Run() {
 	var response ansible.Response
 
 	// Check if argument file is provided

--- a/plugins/modules/src/module_dispatcher/module_dispatcher.go
+++ b/plugins/modules/src/module_dispatcher/module_dispatcher.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"vmware-migration-kit/plugins/modules/src/best_match_flavor"
 	"vmware-migration-kit/plugins/modules/src/create_heat_stack"
@@ -51,6 +52,8 @@ var dispatch = map[string]func(){
 
 func main() {
 	name := filepath.Base(os.Args[0])
+	name = strings.TrimPrefix(name, "AnsiballZ_")
+	name = strings.TrimSuffix(name, ".py")
 	if fn, ok := dispatch[name]; ok {
 		fn()
 		return

--- a/plugins/modules/src/module_dispatcher/module_dispatcher.go
+++ b/plugins/modules/src/module_dispatcher/module_dispatcher.go
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 Red Hat, Inc.
+ *
+ */
+
+// module_dispatcher is a single binary that dispatches to all pure-Go Ansible modules
+// based on the basename of argv[0].  Each module is installed as a symlink to
+// this binary so the tarball stores the executable data only once, staying
+// well under the Ansible Galaxy 20 MB upload limit.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"vmware-migration-kit/plugins/modules/src/best_match_flavor"
+	"vmware-migration-kit/plugins/modules/src/create_heat_stack"
+	"vmware-migration-kit/plugins/modules/src/create_network_port"
+	"vmware-migration-kit/plugins/modules/src/create_server"
+	"vmware-migration-kit/plugins/modules/src/flavor_info"
+	"vmware-migration-kit/plugins/modules/src/generate_heat_template"
+	"vmware-migration-kit/plugins/modules/src/import_flavor"
+	"vmware-migration-kit/plugins/modules/src/volume_info"
+	"vmware-migration-kit/plugins/modules/src/volume_metadata_info"
+)
+
+var dispatch = map[string]func(){
+	"best_match_flavor":      best_match_flavor.Run,
+	"create_heat_stack":      create_heat_stack.Run,
+	"create_network_port":    create_network_port.Run,
+	"create_server":          create_server.Run,
+	"flavor_info":            flavor_info.Run,
+	"generate_heat_template": generate_heat_template.Run,
+	"import_flavor":          import_flavor.Run,
+	"volume_info":            volume_info.Run,
+	"volume_metadata_info":   volume_metadata_info.Run,
+}
+
+func main() {
+	name := filepath.Base(os.Args[0])
+	if fn, ok := dispatch[name]; ok {
+		fn()
+		return
+	}
+	fmt.Fprintf(os.Stderr, "module_dispatcher: unknown module %q — "+
+		"must be invoked via a symlink named after a supported module\n", name)
+	os.Exit(1)
+}

--- a/plugins/modules/src/module_dispatcher/module_dispatcher.go
+++ b/plugins/modules/src/module_dispatcher/module_dispatcher.go
@@ -31,6 +31,10 @@ import (
 	"vmware-migration-kit/plugins/modules/src/create_heat_stack"
 	"vmware-migration-kit/plugins/modules/src/create_network_port"
 	"vmware-migration-kit/plugins/modules/src/create_server"
+	"vmware-migration-kit/plugins/modules/src/delete_flavor"
+	"vmware-migration-kit/plugins/modules/src/delete_port"
+	"vmware-migration-kit/plugins/modules/src/delete_server"
+	"vmware-migration-kit/plugins/modules/src/delete_volume"
 	"vmware-migration-kit/plugins/modules/src/flavor_info"
 	"vmware-migration-kit/plugins/modules/src/generate_heat_template"
 	"vmware-migration-kit/plugins/modules/src/import_flavor"
@@ -43,6 +47,10 @@ var dispatch = map[string]func(){
 	"create_heat_stack":      create_heat_stack.Run,
 	"create_network_port":    create_network_port.Run,
 	"create_server":          create_server.Run,
+	"delete_flavor":          delete_flavor.Run,
+	"delete_port":            delete_port.Run,
+	"delete_server":          delete_server.Run,
+	"delete_volume":          delete_volume.Run,
 	"flavor_info":            flavor_info.Run,
 	"generate_heat_template": generate_heat_template.Run,
 	"import_flavor":          import_flavor.Run,

--- a/plugins/modules/src/volume_info/volume_info.go
+++ b/plugins/modules/src/volume_info/volume_info.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package main
+package volume_info
 
 import (
 	"context"
@@ -75,7 +75,7 @@ func returnResponse(responseBody Response) {
 	}
 }
 
-func main() {
+func Run() {
 	var response Response
 	if len(os.Args) != 2 {
 		response.Msg = "No argument file provided"

--- a/plugins/modules/src/volume_metadata_info/volume_metadata_info.go
+++ b/plugins/modules/src/volume_metadata_info/volume_metadata_info.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package main
+package volume_metadata_info
 
 import (
 	"context"
@@ -65,7 +65,7 @@ func returnResponse(responseBody Response) {
 	}
 }
 
-func main() {
+func Run() {
 	var response Response
 	if len(os.Args) != 2 {
 		response.Msg = "No argument file provided"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,20 +20,35 @@ fi
 
 cd /code || exit
 modules_dir="plugins/modules"
-if [ -d "${modules_dir}" ]; then
-  for folder in "${modules_dir}"/src/*; do
-    if [ -d "${folder}" ]; then
-      outbin="/code/${modules_dir}/$(basename "${folder}")"
-      pushd "${folder}" || return
-      go build -ldflags="-s -w" -a -o "$outbin"
-      popd || return
-      if [ "$HAVE_UPX" = true ]; then
-        echo "Compressing $outbin ..."
-        upx --best --lzma --force "$outbin" || echo "UPX failed on $outbin, continuing..."
-      fi
-    fi
-  done
-else
+if [ ! -d "${modules_dir}" ]; then
   echo "Can't find ${modules_dir} directory, probably we're not in the collection root"
   exit 1
 fi
+
+# Single pass over all src/ subdirectories:
+#   - package main  -> compile as standalone binary
+#   - library package -> create a symlink to module_dispatcher so Ansible
+#                        wrappers keep working without maintaining a list
+for folder in "${modules_dir}"/src/*; do
+  [ -d "${folder}" ] || continue
+
+  module_name="$(basename "${folder}")"
+  pushd "${folder}" || exit
+  pkg_name="$(go list -f '{{.Name}}' .)"
+  popd || exit
+
+  if [ "${pkg_name}" = "main" ]; then
+    outbin="/code/${modules_dir}/${module_name}"
+    echo "Building ${module_name} ..."
+    pushd "${folder}" || exit
+    go build -trimpath -ldflags="-s -w -buildid=" -o "$outbin"
+    popd || exit
+    if [ "$HAVE_UPX" = true ]; then
+      echo "Compressing $outbin ..."
+      upx --best --lzma --force "$outbin" || echo "UPX failed on $outbin, continuing..."
+    fi
+  else
+    echo "Symlinking ${module_name} -> module_dispatcher"
+    ln -sf module_dispatcher "/code/${modules_dir}/${module_name}"
+  fi
+done

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -14,3 +14,5 @@ plugins/modules/volume_metadata_info.py validate-modules:missing-gplv3-license
 plugins/modules/import_flavor.py validate-modules:missing-gplv3-license
 plugins/modules/create_heat_stack.py validate-modules:missing-gplv3-license
 plugins/modules/generate_heat_template.py validate-modules:missing-gplv3-license
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:invalid-extension
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:python-syntax-error

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -14,3 +14,5 @@ plugins/modules/volume_metadata_info.py validate-modules:missing-gplv3-license
 plugins/modules/import_flavor.py validate-modules:missing-gplv3-license
 plugins/modules/create_heat_stack.py validate-modules:missing-gplv3-license
 plugins/modules/generate_heat_template.py validate-modules:missing-gplv3-license
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:invalid-extension
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:python-syntax-error

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -42,3 +42,5 @@ plugins/modules/src/import_flavor/import_flavor.go validate-modules:python-synta
 plugins/modules/src/migrate/migrate.go validate-modules:python-syntax-error
 plugins/modules/src/volume_info/volume_info.go validate-modules:python-syntax-error
 plugins/modules/src/volume_metadata_info/volume_metadata_info.go validate-modules:python-syntax-error
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:invalid-extension
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:python-syntax-error

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -14,3 +14,5 @@ plugins/modules/volume_metadata_info.py validate-modules:missing-gplv3-license
 plugins/modules/import_flavor.py validate-modules:missing-gplv3-license
 plugins/modules/create_heat_stack.py validate-modules:missing-gplv3-license
 plugins/modules/generate_heat_template.py validate-modules:missing-gplv3-license
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:invalid-extension
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:python-syntax-error

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -14,3 +14,5 @@ plugins/modules/volume_metadata_info.py validate-modules:missing-gplv3-license
 plugins/modules/import_flavor.py validate-modules:missing-gplv3-license
 plugins/modules/create_heat_stack.py validate-modules:missing-gplv3-license
 plugins/modules/generate_heat_template.py validate-modules:missing-gplv3-license
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:invalid-extension
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:python-syntax-error

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -14,3 +14,5 @@ plugins/modules/volume_metadata_info.py validate-modules:missing-gplv3-license
 plugins/modules/import_flavor.py validate-modules:missing-gplv3-license
 plugins/modules/create_heat_stack.py validate-modules:missing-gplv3-license
 plugins/modules/generate_heat_template.py validate-modules:missing-gplv3-license
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:invalid-extension
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:python-syntax-error

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -14,3 +14,5 @@ plugins/modules/volume_metadata_info.py validate-modules:missing-gplv3-license
 plugins/modules/import_flavor.py validate-modules:missing-gplv3-license
 plugins/modules/create_heat_stack.py validate-modules:missing-gplv3-license
 plugins/modules/generate_heat_template.py validate-modules:missing-gplv3-license
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:invalid-extension
+plugins/modules/src/module_dispatcher/module_dispatcher.go validate-modules:python-syntax-error


### PR DESCRIPTION
Implementation of a Multicall Binary Dispatcher Architecture:

- A single compiled binary (module_dispatcher) contains all the logic for all modules, and each module is converted from package main → package <module> with a Run() function.
- Symlinks per module point to module_dispatcher instead of separate binaries so they can be called from Ansible.
- Before (9 separate binaries): After (1 binary + 9 symlinks): Savings: ~75% binary size (16.5 MB / 6.5 MB for the production build)
- Adaptation of the Makefile and build script to account for the change