### PR TITLE
filter at port creation when use_fixed_ips is set

### DIFF
--- a/plugins/module_utils/utils.go
+++ b/plugins/module_utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/fs"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -56,6 +57,23 @@ func FDevName(
 		}
 	}
 	return "", nil
+}
+
+func FixedIPsForNeutron(ips []string) []string {
+	if len(ips) == 0 {
+		return nil
+	}
+	var out []string
+	for _, s := range ips {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			continue
+		}
+		if ip4 := ip.To4(); ip4 != nil {
+			out = append(out, ip4.String())
+		}
+	}
+	return out
 }
 
 func GenRandom(length int) (string, error) {
@@ -97,7 +115,7 @@ var transliterations = map[rune]string{
 	'ì': "i", 'ò': "o",
 	'Ì': "I", 'Ò': "O",
 	// Common special characters
-	'·':    "_", // interpunct
+	'·':      "_", // interpunct
 	'\u2019': "_", // right single quotation mark
 	'\u2013': "_", // en-dash
 	'\u2014': "_", // em-dash

--- a/plugins/module_utils/utils_ip_test.go
+++ b/plugins/module_utils/utils_ip_test.go
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+package moduleutils
+
+import "testing"
+
+func TestFixedIPsForNeutron_IPv4AndIPv6Mixed(t *testing.T) {
+	in := []string{"10.13.45.24", "fe80::123:56ff:1234:143a", "2001:db8::1"}
+	got := FixedIPsForNeutron(in)
+	if len(got) != 1 || got[0] != "10.13.45.24" {
+		t.Errorf("expected [10.13.45.24], got %#v", got)
+	}
+}
+
+func TestFixedIPsForNeutron_OnlyLinkLocalV6(t *testing.T) {
+	in := []string{"fe80::1", "fe80::1234:5678:9abc:def0"}
+	got := FixedIPsForNeutron(in)
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %#v", got)
+	}
+}
+
+func TestFixedIPsForNeutron_Empty(t *testing.T) {
+	if got := FixedIPsForNeutron(nil); got != nil {
+		t.Errorf("expected nil, got %#v", got)
+	}
+	if got := FixedIPsForNeutron([]string{}); got != nil {
+		t.Errorf("expected nil, got %#v", got)
+	}
+}
+
+func TestFixedIPsForNeutron_InvalidSkipped(t *testing.T) {
+	in := []string{"not-an-ip", "10.0.0.1"}
+	got := FixedIPsForNeutron(in)
+	if len(got) != 1 || got[0] != "10.0.0.1" {
+		t.Errorf("expected [10.0.0.1], got %#v", got)
+	}
+}

--- a/plugins/modules/create_network_port.py
+++ b/plugins/modules/create_network_port.py
@@ -49,6 +49,8 @@ options:
   use_fixed_ips:
     description:
       - Whether to assign fixed IPs to the created ports based on the IP addresses found in the nics file.
+      - Only IPv4 addresses are used and other IPv6 addresses from VMware metadata are ignored
+        so Neutron fixed IPs can target a single IPv4 subnet without requiring matching IPv6 subnets.
     type: bool
     default: false
     required: false

--- a/plugins/modules/src/create_network_port/create_network_port.go
+++ b/plugins/modules/src/create_network_port/create_network_port.go
@@ -165,6 +165,8 @@ func main() {
 		}
 		if !moduleArgs.UseFixedIPs {
 			nic.FixedIPs = nil
+		} else {
+			nic.FixedIPs = moduleutils.FixedIPsForNeutron(nic.FixedIPs)
 		}
 		// If using fixed IPs, get subnet ID if not provided
 		if moduleArgs.UseFixedIPs {


### PR DESCRIPTION
This PR fixes a bug in `create_network_port` steps for handling ipv4/ipv6 into neutron. See: https://redhat.atlassian.net/browse/OSPRH-27834