### PR TITLE
discover all disk keys from disk_info for data_volume_ids

### DIFF
--- a/plugins/modules/generate_heat_template.py
+++ b/plugins/modules/generate_heat_template.py
@@ -17,6 +17,7 @@ options:
     description:
       - List of VM data dictionaries containing migration information.
       - Each VM must have name, boot_volume_id, flavor, network, and security_groups.
+      - Optional data_volume_ids lists additional Cinder volumes to attach to the instance.
     required: true
     type: list
     elements: dict
@@ -38,6 +39,8 @@ EXAMPLES = r"""
     vms_data:
       - name: rhel-1
         boot_volume_id: "volume-uuid-1"
+        data_volume_ids:
+          - "volume-uuid-1-data"
         flavor: "m1.medium"
         network: "provider_network_1"
         security_groups: ["default"]

--- a/plugins/modules/src/generate_heat_template/generate_heat_template.go
+++ b/plugins/modules/src/generate_heat_template/generate_heat_template.go
@@ -74,7 +74,7 @@ func sanitizeName(name string) string {
 	return sanitized
 }
 
-func generateHeatTemplate(vmsData []VMData, stackName string) (string, map[string]interface{}) {
+func GenerateHeatTemplate(vmsData []VMData, stackName string) (string, map[string]interface{}) {
 	var template strings.Builder
 	parameters := make(map[string]interface{})
 
@@ -204,7 +204,7 @@ func Run() {
 	}
 
 	// Generate Heat template
-	templateContent, parameters := generateHeatTemplate(moduleArgs.VMsData, moduleArgs.StackName)
+	templateContent, parameters := GenerateHeatTemplate(moduleArgs.VMsData, moduleArgs.StackName)
 
 	// Ensure output directory exists
 	err = os.MkdirAll(moduleArgs.OutputDir, 0755)

--- a/plugins/modules/src/generate_heat_template/generate_heat_template_test.go
+++ b/plugins/modules/src/generate_heat_template/generate_heat_template_test.go
@@ -14,7 +14,7 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package main
+package generate_heat_template
 
 import (
 	"strings"

--- a/plugins/modules/src/generate_heat_template/generate_heat_template_test.go
+++ b/plugins/modules/src/generate_heat_template/generate_heat_template_test.go
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 Red Hat, Inc.
+ *
+ */
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateHeatTemplateWithDataVolumes(t *testing.T) {
+	vmsData := []VMData{
+		{
+			Name:           "vm-02-2d",
+			BootVolumeID:   "boot-volume-uuid",
+			Flavor:         "flavor-uuid",
+			Network:        "network-uuid",
+			SecurityGroups: []string{"default"},
+			DataVolumeIDs:  []string{"data-volume-uuid"},
+		},
+	}
+
+	template, parameters := generateHeatTemplate(vmsData, "os-migrate-test")
+
+	if !strings.Contains(template, "vm_02_2d_data_volume_0_id") {
+		t.Fatalf("expected data volume parameter in template, got:\n%s", template)
+	}
+
+	if !strings.Contains(template, "vm_02_2d_data_volume_0:") {
+		t.Fatalf("expected data volume resource in template, got:\n%s", template)
+	}
+
+	if !strings.Contains(template, "volume_id: { get_resource: vm_02_2d_data_volume_0 }") {
+		t.Fatalf("expected data volume in block_device_mapping_v2, got:\n%s", template)
+	}
+
+	if parameters["vm_02_2d_boot_volume_id"] != "boot-volume-uuid" {
+		t.Fatalf("expected boot volume parameter, got %#v", parameters["vm_02_2d_boot_volume_id"])
+	}
+
+	if parameters["vm_02_2d_data_volume_0_id"] != "data-volume-uuid" {
+		t.Fatalf("expected data volume parameter, got %#v", parameters["vm_02_2d_data_volume_0_id"])
+	}
+}
+
+func TestGenerateHeatTemplateBootVolumeOnly(t *testing.T) {
+	vmsData := []VMData{
+		{
+			Name:           "rhel-1",
+			BootVolumeID:   "boot-volume-uuid",
+			Flavor:         "flavor-uuid",
+			Network:        "network-uuid",
+			SecurityGroups: []string{"default"},
+		},
+	}
+
+	template, parameters := generateHeatTemplate(vmsData, "os-migrate-test")
+
+	if strings.Contains(template, "data_volume_0") {
+		t.Fatalf("did not expect data volume resources for single-disk VM, got:\n%s", template)
+	}
+
+	if len(parameters) != 2 {
+		t.Fatalf("expected boot and security group parameters only, got %#v", parameters)
+	}
+}

--- a/roles/import_workloads/tasks/heat_deploy.yml
+++ b/roles/import_workloads/tasks/heat_deploy.yml
@@ -19,15 +19,26 @@
   loop: "{{ vms_list }}"
   register: disk_info_files
 
-- name: Build boot disk key map for each VM
+- name: Build disk key map for each VM
   ansible.builtin.set_fact:
-    vm_boot_disk_keys: >-
+    vm_disk_keys: >-
       {{
-        vm_boot_disk_keys | default({}) | combine({
-          item.item: (item.content | b64decode | from_json).disk_keys[0]
+        vm_disk_keys | default({}) | combine({
+          item.item: (item.content | b64decode | from_json).disk_keys
         })
       }}
   loop: "{{ disk_info_files.results }}"
+
+- name: Build VM disk key pairs for volume lookup
+  ansible.builtin.set_fact:
+    vm_disk_key_pairs: >-
+      {%- set pairs = [] -%}
+      {%- for vm in vms_list -%}
+      {%- for disk_key in vm_disk_keys[vm] -%}
+      {%- set _ = pairs.append({'vm_name': vm, 'disk_key': disk_key, 'volume_name': vm + '-' + disk_key}) -%}
+      {%- endfor -%}
+      {%- endfor -%}
+      {{ pairs }}
 
 - name: Get flavor UUID if flavor name is provided
   os_migrate.vmware_migration_kit.flavor_info:
@@ -35,25 +46,26 @@
     flavor_name: "{{ flavor_name_or_uuid }}"
   register: flavor_info
 
-- name: Gather Cinder volume info for all migrated VMs
+- name: Gather Cinder volume info for all migrated VM disks
   os_migrate.vmware_migration_kit.volume_info:
     cloud: "{{ dst_cloud }}"
-    name: "{{ item }}-{{ vm_boot_disk_keys[item] }}"
-  loop: "{{ vms_list }}"
+    name: "{{ item.volume_name }}"
+  loop: "{{ vm_disk_key_pairs }}"
   register: migrated_volumes_info
 
 - name: Build VM data structure for Heat template
   ansible.builtin.set_fact:
     heat_vms_data: "{{ heat_vms_data + [vm_entry] }}"
+  loop: "{{ vms_list }}"
   vars:
+    vm_volume_results: "{{ migrated_volumes_info.results | selectattr('item.vm_name', 'equalto', item) | list }}"
     vm_entry:
-      name: "{{ item.item }}"
-      boot_volume_id: "{{ item.volumes[0].id }}"
+      name: "{{ item }}"
+      boot_volume_id: "{{ vm_volume_results[0].volumes[0].id }}"
+      data_volume_ids: "{{ vm_volume_results[1:] | map(attribute='volumes.0.id') | list }}"
       flavor: "{{ flavor_info.flavor.id }}"
       network: "{{ openstack_private_network }}"
       security_groups: ["{{ security_groups | default('default') }}"]
-      data_volume_ids: []
-  loop: "{{ migrated_volumes_info.results }}"
 
 - name: Display VM data for Heat template
   ansible.builtin.debug:

--- a/tests/unit/generate_heat_template_test.go
+++ b/tests/unit/generate_heat_template_test.go
@@ -14,15 +14,18 @@
  * Copyright 2025 Red Hat, Inc.
  *
  */
-package generate_heat_template
+
+package moduleutils
 
 import (
 	"strings"
 	"testing"
+
+	generateheattemplate "vmware-migration-kit/plugins/modules/src/generate_heat_template"
 )
 
 func TestGenerateHeatTemplateWithDataVolumes(t *testing.T) {
-	vmsData := []VMData{
+	vmsData := []generateheattemplate.VMData{
 		{
 			Name:           "vm-02-2d",
 			BootVolumeID:   "boot-volume-uuid",
@@ -33,7 +36,7 @@ func TestGenerateHeatTemplateWithDataVolumes(t *testing.T) {
 		},
 	}
 
-	template, parameters := generateHeatTemplate(vmsData, "os-migrate-test")
+	template, parameters := generateheattemplate.GenerateHeatTemplate(vmsData, "os-migrate-test")
 
 	if !strings.Contains(template, "vm_02_2d_data_volume_0_id") {
 		t.Fatalf("expected data volume parameter in template, got:\n%s", template)
@@ -57,7 +60,7 @@ func TestGenerateHeatTemplateWithDataVolumes(t *testing.T) {
 }
 
 func TestGenerateHeatTemplateBootVolumeOnly(t *testing.T) {
-	vmsData := []VMData{
+	vmsData := []generateheattemplate.VMData{
 		{
 			Name:           "rhel-1",
 			BootVolumeID:   "boot-volume-uuid",
@@ -67,7 +70,7 @@ func TestGenerateHeatTemplateBootVolumeOnly(t *testing.T) {
 		},
 	}
 
-	template, parameters := generateHeatTemplate(vmsData, "os-migrate-test")
+	template, parameters := generateheattemplate.GenerateHeatTemplate(vmsData, "os-migrate-test")
 
 	if strings.Contains(template, "data_volume_0") {
 		t.Fatalf("did not expect data volume resources for single-disk VM, got:\n%s", template)


### PR DESCRIPTION
This PR aims to fix https://github.com/os-migrate/vmware-migration-kit/issues/252 where the template generator already supports data volumes; `heat_deploy.yml` just always passes an empty `data_volume_ids` list. Updating it to discover and attach all migrated disks.